### PR TITLE
Don't Convert String Keys to Numbers, Even if the Generic is Numeric

### DIFF
--- a/src/Internal/TypeAdapter/ArrayTypeAdapter.php
+++ b/src/Internal/TypeAdapter/ArrayTypeAdapter.php
@@ -103,7 +103,7 @@ final class ArrayTypeAdapter extends TypeAdapter
                         case 2:
                             /** @var PhpType $keyType */
                             $keyType = $generics[0];
-                            if ($keyType->isString()) {
+                            if ($keyType->isString() || !is_numeric($name)) {
                                 $name = sprintf('"%s"', $name);
                             }
 


### PR DESCRIPTION
This addresses issue [#2 Integer-keyed Generics Don't Throw Exception on String Key](https://github.com/tebru/gson-php/issues/2).