### PR TITLE
Improving handling of deserializing into existing object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Change Log
 
 This document keeps track of changes between releases of the library.
 
+master
+------
+
+* FIXED: Issues with default property values and overrides when deserializing into provided object
+
 v0.2.0
 ------
 

--- a/src/GsonBuilder.php
+++ b/src/GsonBuilder.php
@@ -386,7 +386,7 @@ class GsonBuilder
             $constructorConstructor
         );
 
-        return new Gson($typeAdapterProvider, $propertyCollectionFactory, $this->serializeNull);
+        return new Gson($typeAdapterProvider, $this->serializeNull);
     }
 
     /**

--- a/src/Internal/ObjectConstructor/CreateFromInstance.php
+++ b/src/Internal/ObjectConstructor/CreateFromInstance.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson\Internal\ObjectConstructor;
+
+use Tebru\Gson\Internal\ObjectConstructor;
+
+/**
+ * Class CreateFromInstance
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+class CreateFromInstance implements ObjectConstructor
+{
+    /**
+     * The already instantiated object
+     *
+     * @var object
+     */
+    private $object;
+
+    /**
+     * Constructor
+     *
+     * @param object $object
+     */
+    public function __construct($object)
+    {
+        $this->object = $object;
+    }
+
+    /**
+     * Returns the instantiated object
+     *
+     * @return object
+     */
+    public function construct()
+    {
+        return $this->object;
+    }
+}

--- a/src/Internal/ObjectConstructorAware.php
+++ b/src/Internal/ObjectConstructorAware.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson\Internal;
+
+/**
+ * Interface ObjectConstructorAware
+ *
+ * Used on [@see TypeAdapter]s that construct objects
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+interface ObjectConstructorAware
+{
+    /**
+     * Set the object constructor
+     *
+     * @param ObjectConstructor $objectConstructor
+     * @return void
+     */
+    public function setObjectConstructor(ObjectConstructor $objectConstructor): void;
+}

--- a/src/Internal/ObjectConstructorAwareTrait.php
+++ b/src/Internal/ObjectConstructorAwareTrait.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson\Internal;
+
+/**
+ * Class ObjectConstructorAwareTrait
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+trait ObjectConstructorAwareTrait
+{
+    /**
+     * The object constructor instance
+     *
+     * @var ObjectConstructor
+     */
+    protected $objectConstructor;
+
+    /**
+     * Set the object constructor
+     *
+     * @param ObjectConstructor $objectConstructor
+     */
+    public function setObjectConstructor(ObjectConstructor $objectConstructor): void
+    {
+        $this->objectConstructor = $objectConstructor;
+    }
+}

--- a/tests/Unit/GsonTest.php
+++ b/tests/Unit/GsonTest.php
@@ -32,6 +32,7 @@ use Tebru\Gson\Test\Mock\TypeAdapter\Integer1TypeAdapterFactory;
  * Class GsonTest
  *
  * @author Nate Brunette <n@tebru.net>
+ * @covers \Tebru\Gson\Internal\ObjectConstructorAwareTrait
  * @covers \Tebru\Gson\Gson
  * @covers \Tebru\Gson\GsonBuilder
  */
@@ -501,9 +502,23 @@ class GsonTest extends PHPUnit_Framework_TestCase
         $gson = Gson::builder()->build();
 
         /** @var GsonMock $gsonMock */
-        $gsonMock = $gson->fromJson($this->json(), $gsonMock);
+        $returnedObject = $gson->fromJson($this->json(), $gsonMock);
 
-        self::assertFalse($gsonMock->getExclude());
+        self::assertSame($gsonMock, $returnedObject);
+    }
+
+    public function testDeserializeUsesSameObjectNested()
+    {
+        $gsonMock = new GsonMock();
+        $gsonMock->setExclude(false);
+        $gsonMock->setGsonObjectMock(new GsonObjectMock('test'));
+
+        $gson = Gson::builder()->build();
+
+        /** @var GsonMock $gsonMock */
+        $returnedObject = $gson->fromJson($this->json(), $gsonMock);
+
+        self::assertSame($gsonMock, $returnedObject);
     }
 
     public function testSerializeSimple()

--- a/tests/Unit/Internal/ObjectConstructor/CreateFromInstanceTest.php
+++ b/tests/Unit/Internal/ObjectConstructor/CreateFromInstanceTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson\Test\Unit\Internal\ObjectConstructor;
+
+use PHPUnit_Framework_TestCase;
+use Tebru\Gson\Internal\ObjectConstructor\CreateFromInstance;
+use Tebru\Gson\Test\Mock\UserMock;
+
+/**
+ * Class CreateFromInstanceTest
+ *
+ * @author Nate Brunette <n@tebru.net>
+ * @covers \Tebru\Gson\Internal\ObjectConstructor\CreateFromInstance
+ */
+class CreateFromInstanceTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $mock = new UserMock();
+        $instanceCreator = new CreateFromInstance($mock);
+        $object = $instanceCreator->construct();
+
+        self::assertSame($mock, $object);
+    }
+}


### PR DESCRIPTION
Allowing overriding the object constructor on ReflectionTypeAdapter. Created
an interface to type to that allows setter injection. Created a new instance
creator to return the instantiated object. Updated the ReflectionTypeAdapter
to check for nested objects.

Signed-off-by: Nate Brunette <n@tebru.net>