### PR TITLE
Adding runtime data to exclusion strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document keeps track of changes between releases of the library.
 master
 ------
 
+* BC BREAK: Changed ExclusionStrategy interface to accept ExclusionData for access to runtime data
+* BC BREAK: Added `getPayload()` method to JsonReadable interface
 * FIXED: Issues with default property values and overrides when deserializing into provided object
 
 v0.2.0

--- a/docs/Exclusion.md
+++ b/docs/Exclusion.md
@@ -22,7 +22,7 @@ class FooExclusionStrategy implements ExclusionStrategy
         return Foo::class === $classMetadata->getName();
     }
 
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return Foo2::class === $propertyMetadata->getDeclaringClassMetadata->getName()
             && 'bar' === $propertyMetadata->getName();
@@ -30,6 +30,18 @@ class FooExclusionStrategy implements ExclusionStrategy
 }
 ```
 
+The `ExclusionData` parameter allows you to make runtime exclusion
+decisions based on data available during serialization or deserialization.
+The `getData()` method will always return an object. This object will
+be fully hydrated during serialization, but will likely be empty or
+partially hydrated during deserialization unless a hydrated object was
+provided when calling `Gson::fromJson()`.
+
+During deserialization, the `getDeserializePayload()`
+method will return the data that has been `json_decode`'d. During
+serialization, this method will return null. Additionally, there is a
+method `isSerialize()` to check if the exclusion strategy is being
+executed during serialization or deserialization.
 
 Options on the Builder
 ----------------------

--- a/src/ExclusionData.php
+++ b/src/ExclusionData.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson;
+
+/**
+ * Interface ExclusionData
+ *
+ * Contains data that is only available at runtime that is passed to exclusion strategies
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+interface ExclusionData
+{
+    /**
+     * Returns true if the data is available during serialization
+     *
+     * @return bool
+     */
+    public function isSerialize(): bool;
+
+    /**
+     * This will either contain a hydrated object during serialization or the instantiated
+     * object during deserialization.  During deserialization, this object will likely be
+     * empty unless a hydrated object was provided.
+     *
+     * @return object
+     */
+    public function getData();
+
+    /**
+     * During deserialization, this will return the provided json after json_decode. During
+     * serialization, this will return null
+     *
+     * @return mixed|null
+     */
+    public function getDeserializePayload();
+}

--- a/src/ExclusionStrategy.php
+++ b/src/ExclusionStrategy.php
@@ -27,7 +27,8 @@ interface ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool;
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool;
 }

--- a/src/Internal/DefaultExclusionData.php
+++ b/src/Internal/DefaultExclusionData.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+namespace Tebru\Gson\Internal;
+
+use Tebru\Gson\ExclusionData;
+
+/**
+ * Class DefaultExclusionData
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+final class DefaultExclusionData implements ExclusionData
+{
+    /**
+     * If the data is available during serialization or deserialization
+     *
+     * @var bool
+     */
+    private $serialize;
+
+    /**
+     * The object to be serialized or deserialized into
+     *
+     * @var object
+     */
+    private $data;
+
+    /**
+     * The original payload available during deserialization
+     *
+     * @var mixed|null
+     */
+    private $payload;
+
+    /**
+     * Constructor
+     *
+     * @param bool $serialize
+     * @param object $data
+     * @param mixed|null $payload
+     */
+    public function __construct(bool $serialize, $data, $payload = null)
+    {
+        $this->serialize = $serialize;
+        $this->data = $data;
+        $this->payload = $payload;
+    }
+
+    /**
+     * Returns true if the data is available during serialization
+     *
+     * @return bool
+     */
+    public function isSerialize(): bool
+    {
+        return $this->serialize;
+    }
+
+    /**
+     * This will either contain a hydrated object during serialization or the instantiated
+     * object during deserialization.  During deserialization, this object will likely be
+     * empty unless a hydrated object was provided.
+     *
+     * @return object
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * During deserialization, this will return the provided json after json_decode. During
+     * serialization, this will return null
+     *
+     * @return mixed|null
+     */
+    public function getDeserializePayload()
+    {
+        return $this->payload;
+    }
+}

--- a/src/Internal/Excluder.php
+++ b/src/Internal/Excluder.php
@@ -12,6 +12,7 @@ use Tebru\Gson\Annotation\Expose;
 use Tebru\Gson\Annotation\Since;
 use Tebru\Gson\Annotation\Until;
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\Internal\Data\AnnotationSet;
 use Tebru\Gson\PropertyMetadata;
@@ -173,14 +174,14 @@ final class Excluder
      * Uses user-defined strategies
      *
      * @param PropertyMetadata $property
-     * @param bool $serialize
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function excludePropertyByStrategy(PropertyMetadata $property, bool $serialize): bool
+    public function excludePropertyByStrategy(PropertyMetadata $property, ExclusionData $exclusionData): bool
     {
-        $strategies = $serialize ? $this->serializationStrategies : $this->deserializationStrategies;
+        $strategies = $exclusionData->isSerialize() ? $this->serializationStrategies : $this->deserializationStrategies;
         foreach ($strategies as $exclusionStrategy) {
-            if ($exclusionStrategy->shouldSkipProperty($property)) {
+            if ($exclusionStrategy->shouldSkipProperty($property, $exclusionData)) {
                 return true;
             }
         }

--- a/src/Internal/JsonDecodeReader.php
+++ b/src/Internal/JsonDecodeReader.php
@@ -26,11 +26,14 @@ final class JsonDecodeReader extends JsonReader
      */
     public function __construct(string $json)
     {
-        $this->push(json_decode($json));
+        $decodedJson = json_decode($json);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new JsonParseException(sprintf('Could not decode json, the error message was: "%s"', json_last_error_msg()));
         }
+
+        $this->payload = $decodedJson;
+        $this->push($decodedJson);
     }
 
     /**

--- a/src/Internal/JsonElementReader.php
+++ b/src/Internal/JsonElementReader.php
@@ -29,6 +29,7 @@ final class JsonElementReader extends JsonReader
      */
     public function __construct(JsonElement $jsonElement)
     {
+        $this->payload = $jsonElement;
         $this->push($jsonElement);
     }
 

--- a/src/Internal/JsonReader.php
+++ b/src/Internal/JsonReader.php
@@ -61,9 +61,16 @@ abstract class JsonReader implements JsonReadable
      * whenever a new token should be returned with the subsequent call
      * to [@see JsonDecodeReader::peek]
      *
-     * @var
+     * @var int|null
      */
     protected $currentToken;
+
+    /**
+     * The original payload
+     *
+     * @var mixed
+     */
+    protected $payload;
 
     /**
      * Returns an enum representing the type of the next token without consuming it
@@ -179,6 +186,16 @@ abstract class JsonReader implements JsonReadable
     public function skipValue(): void
     {
         $this->pop();
+    }
+
+    /**
+     * Returns the original json after json_decode
+     *
+     * @return mixed
+     */
+    public function getPayload()
+    {
+        return $this->payload;
     }
 
     /**

--- a/src/Internal/ObjectConstructor/CreateFromInstance.php
+++ b/src/Internal/ObjectConstructor/CreateFromInstance.php
@@ -13,7 +13,7 @@ use Tebru\Gson\Internal\ObjectConstructor;
  *
  * @author Nate Brunette <n@tebru.net>
  */
-class CreateFromInstance implements ObjectConstructor
+final class CreateFromInstance implements ObjectConstructor
 {
     /**
      * The already instantiated object

--- a/src/JsonReadable.php
+++ b/src/JsonReadable.php
@@ -115,4 +115,11 @@ interface JsonReadable
      * @return string
      */
     public function getPath(): string;
+
+    /**
+     * Returns the original payload after json_decode
+     *
+     * @return mixed
+     */
+    public function getPayload();
 }

--- a/tests/Mock/ExclusionStrategies/BarPropertyExclusionStrategy.php
+++ b/tests/Mock/ExclusionStrategies/BarPropertyExclusionStrategy.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 
@@ -32,9 +33,10 @@ class BarPropertyExclusionStrategy implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return 'bar' === $propertyMetadata->getName();
     }

--- a/tests/Mock/ExclusionStrategies/ExcludeClassMockExclusionStrategy.php
+++ b/tests/Mock/ExclusionStrategies/ExcludeClassMockExclusionStrategy.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 use Tebru\Gson\Test\Mock\ExcluderVersionMock;
@@ -33,9 +34,10 @@ class ExcludeClassMockExclusionStrategy implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return false;
     }

--- a/tests/Mock/ExclusionStrategies/FooExclusionStrategy.php
+++ b/tests/Mock/ExclusionStrategies/FooExclusionStrategy.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 use Tebru\Gson\Test\Mock\Foo;
@@ -33,9 +34,10 @@ class FooExclusionStrategy implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return false;
     }

--- a/tests/Mock/ExclusionStrategies/FooPropertyExclusionStrategy.php
+++ b/tests/Mock/ExclusionStrategies/FooPropertyExclusionStrategy.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 
@@ -32,9 +33,10 @@ class FooPropertyExclusionStrategy implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return 'foo' === $propertyMetadata->getName();
     }

--- a/tests/Mock/ExclusionStrategies/GsonMockExclusionStrategyMock.php
+++ b/tests/Mock/ExclusionStrategies/GsonMockExclusionStrategyMock.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 use Tebru\Gson\Test\Mock\GsonMock;
@@ -34,9 +35,10 @@ class GsonMockExclusionStrategyMock implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         if (false === $this->skipProperty) {
             return false;

--- a/tests/Mock/ExclusionStrategies/UserMockExclusionStrategy.php
+++ b/tests/Mock/ExclusionStrategies/UserMockExclusionStrategy.php
@@ -7,6 +7,7 @@
 namespace Tebru\Gson\Test\Mock\ExclusionStrategies;
 
 use Tebru\Gson\ClassMetadata;
+use Tebru\Gson\ExclusionData;
 use Tebru\Gson\ExclusionStrategy;
 use Tebru\Gson\PropertyMetadata;
 use Tebru\Gson\Test\Mock\UserMock;
@@ -33,9 +34,10 @@ class UserMockExclusionStrategy implements ExclusionStrategy
      * Return true if the property should be ignored
      *
      * @param PropertyMetadata $propertyMetadata
+     * @param ExclusionData $exclusionData
      * @return bool
      */
-    public function shouldSkipProperty(PropertyMetadata $propertyMetadata): bool
+    public function shouldSkipProperty(PropertyMetadata $propertyMetadata, ExclusionData $exclusionData): bool
     {
         return false;
     }

--- a/tests/Unit/Internal/DefaultExclusionDataTest.php
+++ b/tests/Unit/Internal/DefaultExclusionDataTest.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+namespace Tebru\Gson\Test\Unit\Internal;
+
+use PHPUnit_Framework_TestCase;
+use stdClass;
+use Tebru\Gson\Internal\DefaultExclusionData;
+
+/**
+ * Class DefaultExclusionDataTest
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+class DefaultExclusionDataTest extends PHPUnit_Framework_TestCase
+{
+    public function testIsSerializeTrue()
+    {
+        $exclusionData = new DefaultExclusionData(true, new stdClass());
+        self::assertTrue($exclusionData->isSerialize());
+    }
+
+    public function testIsSerializeFalse()
+    {
+        $exclusionData = new DefaultExclusionData(false, new stdClass());
+        self::assertFalse($exclusionData->isSerialize());
+    }
+
+    public function testGetData()
+    {
+        $data = new stdClass();
+        $data->foo = 'bar';
+
+        $exclusionData = new DefaultExclusionData(false, $data);
+        self::assertSame($data, $exclusionData->getData());
+    }
+
+    public function testGetPayload()
+    {
+        $data = new stdClass();
+        $data->foo = 'bar';
+        $payload = ['foo', 'bar2'];
+
+        $exclusionData = new DefaultExclusionData(false, $data, $payload);
+        self::assertSame($payload, $exclusionData->getDeserializePayload());
+    }
+}

--- a/tests/Unit/Internal/ExcluderTest.php
+++ b/tests/Unit/Internal/ExcluderTest.php
@@ -14,6 +14,7 @@ use Tebru\Gson\Annotation\Since;
 use Tebru\Gson\Annotation\Until;
 use Tebru\Gson\Internal\DefaultClassMetadata;
 use Tebru\Gson\Internal\Data\AnnotationSet;
+use Tebru\Gson\Internal\DefaultExclusionData;
 use Tebru\Gson\Internal\Excluder;
 use Tebru\Gson\Internal\MetadataFactory;
 use Tebru\Gson\Internal\DefaultPropertyMetadata;
@@ -25,6 +26,7 @@ use Tebru\Gson\Test\Mock\ExcluderExposeMock;
 use Tebru\Gson\Test\Mock\ExclusionStrategies\FooExclusionStrategy;
 use Tebru\Gson\Test\Mock\ExclusionStrategies\FooPropertyExclusionStrategy;
 use Tebru\Gson\Test\Mock\Foo;
+use Tebru\Gson\Test\Mock\UserMock;
 use Tebru\Gson\Test\MockProvider;
 use Tebru\PhpType\TypeToken;
 
@@ -532,8 +534,10 @@ class ExcluderTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        self::assertTrue($this->excluder->excludePropertyByStrategy($propertyMetadata, true));
-        self::assertTrue($this->excluder->excludePropertyByStrategy($propertyMetadata, false));
+        $serializeExclusionData = new DefaultExclusionData(true, new UserMock());
+        $deserializeExclusionData = new DefaultExclusionData(false, new UserMock(), ['name' => 'John Doe']);
+        self::assertTrue($this->excluder->excludePropertyByStrategy($propertyMetadata, $serializeExclusionData));
+        self::assertTrue($this->excluder->excludePropertyByStrategy($propertyMetadata, $deserializeExclusionData));
     }
 
     public function testExcludeFromStrategyFalse()
@@ -548,7 +552,9 @@ class ExcluderTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        self::assertFalse($this->excluder->excludePropertyByStrategy($propertyMetadata, true));
-        self::assertFalse($this->excluder->excludePropertyByStrategy($propertyMetadata, false));
+        $serializeExclusionData = new DefaultExclusionData(true, new UserMock());
+        $deserializeExclusionData = new DefaultExclusionData(false, new UserMock(), ['name' => 'John Doe']);
+        self::assertFalse($this->excluder->excludePropertyByStrategy($propertyMetadata, $serializeExclusionData));
+        self::assertFalse($this->excluder->excludePropertyByStrategy($propertyMetadata, $deserializeExclusionData));
     }
 }

--- a/tests/Unit/Internal/JsonDecodeReaderTest.php
+++ b/tests/Unit/Internal/JsonDecodeReaderTest.php
@@ -9,6 +9,7 @@ namespace Tebru\Gson\Test\Unit\Internal;
 use ArrayIterator;
 use PHPUnit_Framework_TestCase;
 use SplStack;
+use stdClass;
 use Tebru\Gson\Exception\JsonParseException;
 use Tebru\Gson\Exception\JsonSyntaxException;
 use Tebru\Gson\Internal\JsonDecodeReader;
@@ -780,6 +781,17 @@ class JsonDecodeReaderTest extends PHPUnit_Framework_TestCase
         $path = $reader->getPath();
 
         self::assertSame('$', $path);
+    }
+
+    public function testGetPayload()
+    {
+        $reader = new JsonDecodeReader('{"name": 1}');
+
+        $payload = $reader->getPayload();
+        $expected = new stdClass();
+        $expected->name = 1;
+
+        self::assertEquals($expected, $payload);
     }
 
     public function provideValidNumbers()

--- a/tests/Unit/Internal/JsonElementReaderTest.php
+++ b/tests/Unit/Internal/JsonElementReaderTest.php
@@ -638,6 +638,17 @@ class JsonElementReaderTest extends PHPUnit_Framework_TestCase
         $reader->endObject();
     }
 
+    public function testGetPayload()
+    {
+        $adapter = new JsonElementTypeAdapter();
+        $jsonObject = $adapter->readFromJson('{"name": 1}');
+        $reader = new JsonElementReader($jsonObject);
+
+        $payload = $reader->getPayload();
+
+        self::assertSame($jsonObject, $payload);
+    }
+
     public function provideValidNumbers()
     {
         return [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [-1]];


### PR DESCRIPTION
ExclusionStrategy now accepts ExclusionData as a second parameter to
shouldSkipProperty(). This allows the strategy to make runtime decisions
on if the property should be excluded based on the provided data.

Signed-off-by: Nate Brunette <n@tebru.net>