### PR TITLE
Updating the documentation registering the loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ composer require tebru/gson-php
 Be sure and set up the annotation loader in one of your initial scripts.
 
 ```
-$loader = require __DIR__ . '/../vendor/autoload.php';
-\Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+use Doctrine\Common\Annotations\AnnotationRegistry;
+AnnotationRegistry::registerLoader('class_exists');
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ composer require tebru/gson-php
 Be sure and set up the annotation loader in one of your initial scripts.
 
 ```
-use Doctrine\Common\Annotations\AnnotationRegistry;
-AnnotationRegistry::registerLoader('class_exists');
+\Doctrine\Common\Annotations\AnnotationRegistry::registerLoader('class_exists');
 ```
 
 License


### PR DESCRIPTION
The `registerLoader` function is deprecated, and it should be fixed in `Doctrine 2.0`. From the documentation it seems we should use it with the `class_exists`

From the documentation:
```
...
deprecated
this method is deprecated and will be removed in doctrine/annotations 2.0 autoloading should be deferred to the globally registered autoloader by then. For now, use @example AnnotationRegistry::registerLoader('class_exists')
```