### PR TITLE
Updating type token factory to use ReflectionDocBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ master
 * Various performance improvements
 * BC BREAK: Modified Reflection and Array type adapter constructors
 * BC BREAK: Removed DefaultClassMetadata::addPropertyMetadata()
+* BC BREAK: Removed support for grouped use statements in type guessing
 * ADDED: getPath() to JsonWritable
 * ADDED: Split ExclusionStrategy into multiple specific interfaces
 * ADDED: deprecations for ExclusionStrategy/ExclusionData
 * ADDED: Payload on exception decoding json data
 * ADDED: Type check on property default
+* ADDED: phpdocumentor/reflection-docblock dependency
 * CHANGE: Order of type guessing
 
 v0.5.9

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">= 7.1",
+        "phpdocumentor/reflection-docblock": "^4.2",
         "tebru/php-type": "^0.1.5",
         "tebru/doctrine-annotation-reader": "^0.3.0",
         "symfony/cache": "^3.3|^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fe4ca161f05e0736105d4c4b4e834dc",
+    "content-hash": "2219d39421728aa0e0a32765133a78b2",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -127,6 +127,158 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "psr/cache",
@@ -417,6 +569,56 @@
             ],
             "description": "A type wrapper for PHP that support generic syntax",
             "time": "2018-07-15T16:49:18+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "packages-dev": [
@@ -521,158 +723,6 @@
                 "object graph"
             ],
             "time": "2018-06-11T23:09:50+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1756,56 +1806,6 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T11:24:31+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],

--- a/tests/Mock/DocblockType/DocblockMock.php
+++ b/tests/Mock/DocblockType/DocblockMock.php
@@ -21,6 +21,8 @@ use Tebru\Gson\Test\Mock\{
     ClassWithParametersInstanceCreator
 };
 
+use Tebru\Gson\Test\Mock\DocblockType\Globals\MyGlobalClassMock;
+
 /**
  * Class DocblockTestClass
  *
@@ -67,6 +69,11 @@ class DocblockMock
      * @var ChildClass
      */
     private $classImported;
+
+    /**
+     * @var MyGlobalClassMock
+     */
+    private $classImportedGlobalConflict;
 
     /**
      * @var \Tebru\Gson\Test\Mock\ChildClass
@@ -139,6 +146,11 @@ class DocblockMock
     private $noTypes;
 
     /**
+     * No tags
+     */
+    private $noTags;
+
+    /**
      * @var ArrayObject
      */
     private $differentGetter;
@@ -160,6 +172,13 @@ class DocblockMock
      * @param int $var
      */
     public function setFoo($var): void
+    {
+    }
+
+    /**
+     * @param int
+     */
+    public function noVariableName($var): void
     {
     }
 

--- a/tests/Mock/DocblockType/Globals/MyGlobalClassMock.php
+++ b/tests/Mock/DocblockType/Globals/MyGlobalClassMock.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Copyright (c) Nate Brunette.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+
+declare(strict_types=1);
+
+namespace Tebru\Gson\Test\Mock\DocblockType\Globals;
+
+/**
+ * Class MyGlobalClassMock
+ *
+ * @author Nate Brunette <n@tebru.net>
+ */
+class MyGlobalClassMock
+{
+
+}

--- a/tests/Mock/DocblockType/globals.php
+++ b/tests/Mock/DocblockType/globals.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace {
+    class MyGlobalClassMock {}
+}

--- a/tests/Unit/Internal/TypeTokenFactoryTest.php
+++ b/tests/Unit/Internal/TypeTokenFactoryTest.php
@@ -22,6 +22,7 @@ use Tebru\Gson\Test\Mock\ClassWithParametersInstanceCreator;
 use Tebru\Gson\Test\Mock\DocblockType\DocblockAliasable;
 use Tebru\Gson\Test\Mock\DocblockType\DocblockFoo;
 use Tebru\Gson\Test\Mock\DocblockType\DocblockMock;
+use Tebru\Gson\Test\Mock\DocblockType\Globals\MyGlobalClassMock;
 use Tebru\Gson\Test\Mock\UserMock;
 use Tebru\PhpType\TypeToken;
 
@@ -167,6 +168,18 @@ class TypeTokenFactoryTest extends PHPUnit_Framework_TestCase
         self::assertSame(ChildClass::class, $phpType->getRawType());
     }
 
+    public function testCreateFromDocblockClassGlobalConflict()
+    {
+        require __DIR__.'/../../Mock/DocblockType/globals.php';
+
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(DocblockMock::class, 'classImportedGlobalConflict');
+        $phpType = $factory->create($annotations, null, null, $property);
+
+        self::assertSame(MyGlobalClassMock::class, $phpType->getRawType());
+    }
+
     public function testCreateFromDocblockClassFullName()
     {
         $annotations = new AnnotationCollection();
@@ -219,6 +232,8 @@ class TypeTokenFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCreateFromDocblockClassGroupedMultipleLines2()
     {
+        $this->markTestSkipped('Skipping until grouped use statements are supported');
+
         $annotations = new AnnotationCollection();
         $factory = new TypeTokenFactory();
         $property = new ReflectionProperty(DocblockMock::class, 'classGroupMultipleLines2');
@@ -229,6 +244,8 @@ class TypeTokenFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCreateFromDocblockClassGroupedMultipleLinesAliased()
     {
+        $this->markTestSkipped('Skipping until grouped use statements are supported');
+
         $annotations = new AnnotationCollection();
         $factory = new TypeTokenFactory();
         $property = new ReflectionProperty(DocblockMock::class, 'classGroupMultipleLinesAliased');
@@ -311,6 +328,16 @@ class TypeTokenFactoryTest extends PHPUnit_Framework_TestCase
         self::assertSame(TypeToken::WILDCARD, $phpType->getRawType());
     }
 
+    public function testCreateFromDocblockNoTags()
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(DocblockMock::class, 'noTags');
+        $phpType = $factory->create($annotations, null, null, $property);
+
+        self::assertSame(TypeToken::WILDCARD, $phpType->getRawType());
+    }
+
     public function testCreateFromDocblockDifferentGetter()
     {
         $annotations = new AnnotationCollection();
@@ -351,6 +378,16 @@ class TypeTokenFactoryTest extends PHPUnit_Framework_TestCase
         $phpType = $factory->create($annotations, null, $setter);
 
         self::assertSame(TypeToken::INTEGER, $phpType->getRawType());
+    }
+
+    public function testCreateFromSetterNoVariable()
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $setter = new ReflectionMethod(DocblockMock::class, 'noVariableName');
+        $phpType = $factory->create($annotations, null, $setter);
+
+        self::assertSame(TypeToken::WILDCARD, $phpType->getRawType());
     }
 
     public function testCreateWildcard()


### PR DESCRIPTION
- Adds phpdocumentor/reflection-docblock dependency
- Allows for better handling of linking aliases
- Temporarily removes support for grouped use statements
- Fixes #29

Signed-off-by: Nate Brunette <n@tebru.net>