### PR TITLE
Fixed docblock parsing for generic array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 
 This document keeps track of changes between releases of the library.
 
+v0.6.3
+------
+* FIXED: Docblock parsing continues checking type locations for generic array
+
 v0.6.2
 ------
 

--- a/src/Internal/TypeTokenFactory.php
+++ b/src/Internal/TypeTokenFactory.php
@@ -151,11 +151,16 @@ final class TypeTokenFactory
         ?ReflectionMethod $getter,
         ?ReflectionMethod $setter
     ): ?TypeToken {
+        $returnTag = null;
+
         if ($getter !== null) {
             $docComment = $getter->getDocComment() ?: null;
             $tag = $this->getTypeFromDoc($getter, $docComment, 'return');
             if ($tag !== null) {
-                return $tag;
+                $returnTag = $tag;
+                if ((string)$tag !== 'array') {
+                    return $tag;
+                }
             }
         }
 
@@ -165,7 +170,10 @@ final class TypeTokenFactory
             if (\count($parameters) === 1) {
                 $tag = $this->getTypeFromDoc($setter, $docComment, 'param', $parameters[0]->getName());
                 if ($tag !== null) {
-                    return $tag;
+                    $returnTag = $tag;
+                    if ((string)$tag !== 'array') {
+                        return $tag;
+                    }
                 }
             }
         }
@@ -174,11 +182,14 @@ final class TypeTokenFactory
             $docComment = $property->getDocComment() ?: null;
             $tag = $this->getTypeFromDoc($property, $docComment, 'var');
             if ($tag !== null) {
-                return $tag;
+                $returnTag = $tag;
+                if ((string)$tag !== 'array') {
+                    return $tag;
+                }
             }
         }
 
-        return null;
+        return $returnTag;
     }
 
     /**
@@ -240,7 +251,7 @@ final class TypeTokenFactory
     {
         $type = $tag->getType();
         if (!$type instanceof Compound) {
-             $type = $this->stripSlashes((string)$type);
+            $type = $this->stripSlashes((string)$type);
 
             return TypeToken::create($this->unwrapArray($type));
         }


### PR DESCRIPTION
Will now continue looking at all locations as long as an 'array' type is
found.

Signed-off-by: Nate Brunette <n@tebru.net>