### PR TITLE
Fixing issue with array type adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 
 This document keeps track of changes between releases of the library.
 
+v0.6.4
+------
+* FIXED: Serializing stdClass with array adapter
+
 v0.6.3
 ------
 * FIXED: Docblock parsing continues checking type locations for generic array

--- a/src/Internal/TypeAdapter/ArrayTypeAdapter.php
+++ b/src/Internal/TypeAdapter/ArrayTypeAdapter.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Tebru\Gson\Internal\TypeAdapter;
 
 use LogicException;
+use stdClass;
 use Tebru\Gson\Exception\JsonSyntaxException;
 use Tebru\Gson\JsonWritable;
 use Tebru\Gson\Internal\TypeAdapterProvider;
@@ -163,7 +164,7 @@ final class ArrayTypeAdapter extends TypeAdapter
      * Write the value to the writer for the type
      *
      * @param JsonWritable $writer
-     * @param array|null $value
+     * @param array|stdClass|null $value
      * @return void
      * @throws \LogicException
      */
@@ -226,11 +227,11 @@ final class ArrayTypeAdapter extends TypeAdapter
 
     /**
      * Returns true if the array is acting like an object
-     * @param array $array
+     * @param array|stdClass $array
      * @param int $numberOfGenerics
      * @return bool
      */
-    private function isArrayObject(array $array, int $numberOfGenerics): bool
+    private function isArrayObject($array, int $numberOfGenerics): bool
     {
         if (2 === $numberOfGenerics) {
             return true;

--- a/tests/Unit/Internal/TypeAdapter/ArrayTypeAdapterTest.php
+++ b/tests/Unit/Internal/TypeAdapter/ArrayTypeAdapterTest.php
@@ -8,6 +8,7 @@ namespace Tebru\Gson\Test\Unit\Internal\TypeAdapter;
 
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Tebru\Gson\Exception\JsonSyntaxException;
 use Tebru\Gson\Internal\TypeAdapter\ArrayTypeAdapter;
 use Tebru\Gson\Internal\TypeAdapter\IntegerTypeAdapter;
@@ -216,6 +217,18 @@ class ArrayTypeAdapterTest extends TestCase
         $adapter = $this->typeAdapterProvider->getAdapter(new TypeToken('array'));
 
         self::assertSame('{"foo":"bar","bar":1}', $adapter->writeToJson(['foo' => 'bar', 'bar' => 1], false));
+    }
+
+    public function testSerializeStdClass(): void
+    {
+        /** @var ArrayTypeAdapter $adapter */
+        $adapter = $this->typeAdapterProvider->getAdapter(new TypeToken('array'));
+
+        $write = new stdClass();
+        $write->foo = 'bar';
+        $write->bar = 1;
+
+        self::assertSame('{"foo":"bar","bar":1}', $adapter->writeToJson($write));
     }
 
     public function testSerializeArrayOneGenericType(): void


### PR DESCRIPTION
When trying to serialize a stdClass, it would fail

Signed-off-by: Nate Brunette <n@tebru.net>