### PR TITLE
feat(cache): support multiple versions of symfony/cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,24 @@ php:
   - 7.3
   - 7.4
 
-matrix:
-  include:
-      - php: 7.1
-        env: dependencies=lowest
+env:
+  - SF_CACHE=3
+  - SF_CACHE=4
+  - SF_CACHE=4.3
+  - SF_CACHE=5
+
+jobs:
+  exclude:
+    - php: 7.1
+      env:
+        - SF_CACHE=5
 
 before_script:
   - composer install --no-interaction -o
-  - if [ "$dependencies" = "lowest" ]; then composer update -o --prefer-lowest; fi;
+  - if [ "$SF_CACHE" = "3" ]; then composer require symfony/cache:^3.3; fi;
+  - if [ "$SF_CACHE" = "4" ]; then composer require symfony/cache:">=4.0 <4.3"; fi;
+  - if [ "$SF_CACHE" = "4.3" ]; then composer require symfony/cache:^4.3; fi;
+  - if [ "$SF_CACHE" = "5" ]; then composer require symfony/cache:5.0; fi;
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">= 7.1",
+        "php": ">=7.1",
         "phpdocumentor/reflection-docblock": "^3.2.3|^4.0.1",
         "tebru/php-type": "^0.1.7",
-        "tebru/doctrine-annotation-reader": "^0.3.6",
-        "symfony/cache": "^3.3|^4.0",
+        "tebru/doctrine-annotation-reader": "^0.3.7",
+        "symfony/cache": "^3.3|^4.0|^5.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/GsonBuilder.php
+++ b/src/GsonBuilder.php
@@ -14,10 +14,6 @@ use InvalidArgumentException;
 use LogicException;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionProperty;
-use Symfony\Component\Cache\Simple\ArrayCache;
-use Symfony\Component\Cache\Simple\ChainCache;
-use Symfony\Component\Cache\Simple\NullCache;
-use Symfony\Component\Cache\Simple\PhpFilesCache;
 use Tebru\AnnotationReader\AnnotationReaderAdapter;
 use Tebru\Gson\Annotation\ExclusionCheck;
 use Tebru\Gson\Context\ReaderContext;
@@ -30,6 +26,7 @@ use Tebru\Gson\Internal\AccessorStrategyFactory;
 use Tebru\Gson\Internal\ConstructorConstructor;
 use Tebru\Gson\Internal\Data\ClassMetadataFactory;
 use Tebru\Gson\Internal\Data\ReflectionPropertySetFactory;
+use Tebru\Gson\Internal\CacheProvider;
 use Tebru\Gson\Internal\DiscriminatorDeserializer;
 use Tebru\Gson\Internal\Excluder;
 use Tebru\Gson\Internal\Naming\DefaultPropertyNamingStrategy;
@@ -523,12 +520,12 @@ class GsonBuilder
 
         if ($this->cache === null) {
             $this->cache = false === $this->enableCache
-                ? new ArrayCache(0, false)
-                : new ChainCache([new ArrayCache(0, false), new PhpFilesCache('', 0, $this->cacheDir)]);
+                ? CacheProvider::createMemoryCache()
+                : CacheProvider::createFileCache($this->cacheDir);
         }
 
         // no need to cache the annotations as they get cached with the class/properties
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
         $excluder = new Excluder();
         $excluder->setVersion($this->version);
         $excluder->setExcludedModifiers($this->excludedModifiers);

--- a/src/Internal/CacheProvider.php
+++ b/src/Internal/CacheProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tebru\Gson\Internal;
+
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ChainAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use Symfony\Component\Cache\Simple\ChainCache;
+use Symfony\Component\Cache\Simple\NullCache;
+use Symfony\Component\Cache\Simple\PhpFilesCache;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class CacheProvider
+{
+    /**
+     * Create a "file cache", chained to a "memory cache" depending on symfony/cache version
+     *
+     * @param string $cacheDir
+     * @return CacheInterface
+     * @throws \Symfony\Component\Cache\Exception\CacheException
+     */
+    public static function createFileCache(string $cacheDir): CacheInterface
+    {
+        // >= Symfony 4.3
+        if (class_exists('Symfony\Component\Cache\Psr16Cache')) {
+            return new Psr16Cache(new ChainAdapter([
+                new Psr16Adapter(self::createMemoryCache()),
+                new PhpFilesAdapter('', 0, $cacheDir),
+            ]));
+        }
+
+        return new ChainCache([
+            self::createMemoryCache(),
+            new PhpFilesCache('', 0, $cacheDir)
+        ]);
+    }
+
+    /**
+     * Create a "memory cache" depending on symfony/cache version
+     *
+     * @return CacheInterface
+     */
+    public static function createMemoryCache(): CacheInterface
+    {
+        // >= Symfony 4.3
+        if (class_exists('Symfony\Component\Cache\Psr16Cache')) {
+            return new Psr16Cache(new ArrayAdapter(0, false));
+        }
+
+        return new ArrayCache(0, false);
+    }
+
+    /**
+     * Create a "null" cache (for annotations) depending on symfony/cache version
+     *
+     * @return CacheInterface
+     */
+    public static function createNullCache(): CacheInterface
+    {
+        // >= Symfony 4.3
+        if (class_exists('Symfony\Component\Cache\Psr16Cache')) {
+            return new Psr16Cache(new NullAdapter());
+        }
+
+        return new NullCache();
+    }
+}

--- a/tests/MockProvider.php
+++ b/tests/MockProvider.php
@@ -9,12 +9,12 @@ namespace Tebru\Gson\Test;
 use DateTime;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\Simple\NullCache;
 use Tebru\AnnotationReader\AnnotationReaderAdapter;
 use Tebru\Gson\Context\ReaderContext;
 use Tebru\Gson\Context\WriterContext;
 use Tebru\Gson\Internal\AccessorMethodProvider;
 use Tebru\Gson\Internal\AccessorStrategyFactory;
+use Tebru\Gson\Internal\CacheProvider;
 use Tebru\Gson\Internal\ConstructorConstructor;
 use Tebru\Gson\Internal\Data\ClassMetadataFactory;
 use Tebru\Gson\Internal\Data\PropertyCollection;
@@ -49,7 +49,7 @@ class MockProvider
     public static function annotationReader(CacheInterface $cache = null)
     {
         if (null === $cache) {
-            $cache = new NullCache();
+            $cache = CacheProvider::createNullCache();
         }
 
         return new AnnotationReaderAdapter(new AnnotationReader(), $cache);
@@ -76,7 +76,7 @@ class MockProvider
             new AccessorStrategyFactory(),
             new TypeTokenFactory(),
             $excluder,
-            new NullCache()
+            CacheProvider::createNullCache()
         );
     }
 

--- a/tests/Unit/GsonTest.php
+++ b/tests/Unit/GsonTest.php
@@ -10,12 +10,12 @@ use DateTime;
 use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
 use ReflectionProperty;
-use Symfony\Component\Cache\Simple\ChainCache;
-use Symfony\Component\Cache\Simple\NullCache;
 use Tebru\Gson\Context\ReaderContext;
 use Tebru\Gson\Context\WriterContext;
 use Tebru\Gson\Gson;
+use Tebru\Gson\Internal\CacheProvider;
 use Tebru\Gson\Internal\Naming\UpperCaseMethodNamingStrategy;
 use Tebru\Gson\PropertyNamingPolicy;
 use Tebru\Gson\Test\Mock\ChildClass;
@@ -735,7 +735,7 @@ class GsonTest extends TestCase
             ->setWriterContext($context)
             ->build();
         $result = $gson->toJson(new GsonMock());
-        
+
         $expected = '{
             "integer": null,
             "float": null,
@@ -994,7 +994,7 @@ class GsonTest extends TestCase
             ->enableCache(true);
         $gsonBuilder->build();
 
-        self::assertAttributeInstanceOf(ChainCache::class, 'cache', $gsonBuilder);
+        self::assertAttributeInstanceOf(CacheInterface::class, 'cache', $gsonBuilder);
     }
 
     public function testEnableCacheWithoutDirectoryThrowsException(): void
@@ -1012,8 +1012,9 @@ class GsonTest extends TestCase
 
     public function testCanOverrideCache(): void
     {
+        $cache = CacheProvider::createNullCache();
         $gson = Gson::builder()
-            ->setCache(new NullCache())
+            ->setCache($cache)
             ->build();
 
         $gsonMock = $gson->fromJson($this->json(), GsonMock::class);

--- a/tests/Unit/Internal/Data/ClassMetadataFactoryTest.php
+++ b/tests/Unit/Internal/Data/ClassMetadataFactoryTest.php
@@ -8,8 +8,6 @@ namespace Tebru\Gson\Test\Unit\Internal\Data;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Simple\ArrayCache;
-use Symfony\Component\Cache\Simple\NullCache;
 use Tebru\AnnotationReader\AnnotationCollection;
 use Tebru\AnnotationReader\AnnotationReaderAdapter;
 use Tebru\Gson\Internal\AccessorMethodProvider;
@@ -21,6 +19,7 @@ use Tebru\Gson\Internal\AccessorStrategy\SetByMethod;
 use Tebru\Gson\Internal\AccessorStrategy\SetByNull;
 use Tebru\Gson\Internal\AccessorStrategy\SetByPublicProperty;
 use Tebru\Gson\Internal\AccessorStrategyFactory;
+use Tebru\Gson\Internal\CacheProvider;
 use Tebru\Gson\Internal\Data\ClassMetadataFactory;
 use Tebru\Gson\Internal\Data\PropertyCollection;
 use Tebru\Gson\Internal\Data\ReflectionPropertySetFactory;
@@ -104,8 +103,8 @@ class ClassMetadataFactoryTest extends TestCase
 
     public function testCreateUsesCache(): void
     {
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
-        $cache = new ArrayCache();
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
+        $cache = CacheProvider::createMemoryCache();
 
         $factory = new ClassMetadataFactory(
             new ReflectionPropertySetFactory(),

--- a/tests/Unit/Internal/Naming/PropertyNamerTest.php
+++ b/tests/Unit/Internal/Naming/PropertyNamerTest.php
@@ -10,8 +10,8 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionProperty;
-use Symfony\Component\Cache\Simple\NullCache;
 use Tebru\AnnotationReader\AnnotationReaderAdapter;
+use Tebru\Gson\Internal\CacheProvider;
 use Tebru\Gson\Internal\Naming\PropertyNamer;
 use Tebru\Gson\Internal\Naming\DefaultPropertyNamingStrategy;
 use Tebru\Gson\PropertyNamingPolicy;
@@ -29,7 +29,7 @@ class PropertyNamerTest extends TestCase
     {
         $namer = new PropertyNamer(new DefaultPropertyNamingStrategy(PropertyNamingPolicy::LOWER_CASE_WITH_UNDERSCORES));
         $reflectionProperty = new ReflectionProperty(AnnotatedMock::class, 'fooBar');
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
         $annotations = $annotationReader->readProperty(
             $reflectionProperty->getName(),
             $reflectionProperty->getDeclaringClass()->getName(),
@@ -44,7 +44,7 @@ class PropertyNamerTest extends TestCase
     {
         $namer = new PropertyNamer(new DefaultPropertyNamingStrategy(PropertyNamingPolicy::LOWER_CASE_WITH_UNDERSCORES));
         $reflectionMethod = new ReflectionMethod(AnnotatedMock::class, 'virtualFoo');
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
         $annotations = $annotationReader->readMethod(
             $reflectionMethod->getName(),
             $reflectionMethod->getDeclaringClass()->getName(),
@@ -59,7 +59,7 @@ class PropertyNamerTest extends TestCase
     {
         $namer = new PropertyNamer(new DefaultPropertyNamingStrategy(PropertyNamingPolicy::LOWER_CASE_WITH_UNDERSCORES));
         $reflectionMethod = new ReflectionMethod(AnnotatedMock::class, 'virtualFooWithSerializedName');
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
         $annotations = $annotationReader->readMethod(
             $reflectionMethod->getName(),
             $reflectionMethod->getDeclaringClass()->getName(),
@@ -74,7 +74,7 @@ class PropertyNamerTest extends TestCase
     {
         $namer = new PropertyNamer(new DefaultPropertyNamingStrategy(PropertyNamingPolicy::LOWER_CASE_WITH_UNDERSCORES));
         $reflectionProperty = new ReflectionProperty(AnnotatedMock::class, 'fooBarBaz');
-        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), new NullCache());
+        $annotationReader = new AnnotationReaderAdapter(new AnnotationReader(), CacheProvider::createNullCache());
         $annotations = $annotationReader->readProperty(
             $reflectionProperty->getName(),
             $reflectionProperty->getDeclaringClass()->getName(),


### PR DESCRIPTION
Create a `DefaultCacheProvider` to create the appropriate instance of cache depending on symfony cache version.
This is to support versions `^3.3|^4.0|^5.0` of `symfony/cache` (since 4.3, classes in `Simple` namespace are deprecated, and removed in 5.x)