### PR TITLE
Adding support for PHP 7.4 typed properties

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,7 @@ build:
         tests-and-coverage:
             environment:
                 php:
-                    version: 7.1
+                    version: 7.4
             tests:
                 override:
                     - phpcs-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 
 language: php
 php:
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
 
 env:
@@ -12,12 +9,6 @@ env:
   - SF_CACHE=4
   - SF_CACHE=4.3
   - SF_CACHE=5
-
-jobs:
-  exclude:
-    - php: 7.1
-      env:
-        - SF_CACHE=5
 
 before_script:
   - composer install --no-interaction -o

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "phpdocumentor/reflection-docblock": "^3.2.3|^4.0.1",
         "tebru/php-type": "^0.1.7",
         "tebru/doctrine-annotation-reader": "^0.3.7",

--- a/src/Internal/TypeTokenFactory.php
+++ b/src/Internal/TypeTokenFactory.php
@@ -100,6 +100,11 @@ final class TypeTokenFactory
             }
         }
 
+        if ($property !== null && $property->getType() !== null) {
+            $propertyType = TypeToken::create($property->getType()->getName());
+            return $this->checkGenericArray($propertyType, $property, $getterMethod, $setterMethod);
+        }
+
         $type = $this->checkDocBlocks($property, $getterMethod, $setterMethod);
         if ($type !== null) {
             return $this->checkGenericArray(

--- a/tests/Mock/AddressMock.php
+++ b/tests/Mock/AddressMock.php
@@ -18,10 +18,7 @@ class AddressMock
      */
     private $street;
 
-    /**
-     * @var string
-     */
-    private $city;
+    private string $city;
 
     /**
      * @var string

--- a/tests/Mock/AnnotatedMock.php
+++ b/tests/Mock/AnnotatedMock.php
@@ -21,7 +21,7 @@ class AnnotatedMock
      */
     private $fooBar;
 
-    private $fooBarBaz;
+    private float $fooBarBaz;
 
     /**
      * @Gson\VirtualProperty("vfoo")

--- a/tests/Mock/ChildClass.php
+++ b/tests/Mock/ChildClass.php
@@ -41,6 +41,8 @@ class ChildClass extends ChildClassParent
      */
     private $default = 1;
 
+    private array $typedArray;
+
     public function getBaz()
     {
         return $this->baz;

--- a/tests/Mock/ChildClassParent.php
+++ b/tests/Mock/ChildClassParent.php
@@ -26,6 +26,6 @@ class ChildClassParent extends ChildClassParent2
      * @QuxAnnotation("qux")
      */
     private $foo;
-    private $bar;
+    private string $bar;
     protected $baz;
 }

--- a/tests/Mock/ClassWithoutParent.php
+++ b/tests/Mock/ClassWithoutParent.php
@@ -24,7 +24,7 @@ class ClassWithoutParent
      * @FooAnnotation("foo")
      * @BarAnnotation("bar")
      */
-    private $foo;
+    private int $foo;
 
     /**
      * @FooAnnotation("foo2")

--- a/tests/Mock/DocblockType/DocblockMock.php
+++ b/tests/Mock/DocblockType/DocblockMock.php
@@ -113,12 +113,17 @@ class DocblockMock
     /**
      * @var ArrayObject
      */
-    private $classGlobal;
+    private ArrayObject $classGlobal;
 
     /**
      * @var array
      */
     private $array;
+
+    /**
+     * @var int[]
+     */
+    private array $fullyTypedArray;
 
     /**
      * @var int[]
@@ -161,6 +166,16 @@ class DocblockMock
     private $differentSetter;
 
     /**
+     * @var ArrayObject
+     */
+    private ArrayObject $differentGetterTyped;
+
+    /**
+     * @var ArrayObject
+     */
+    private ArrayObject $differentSetterTyped;
+
+    /**
      * @return int
      */
     public function getFoo()
@@ -196,5 +211,21 @@ class DocblockMock
     public function setDifferentSetter(array $foos): void
     {
         $this->differentSetter = $foos;
+    }
+
+    /**
+     * @return DocblockFoo[]
+     */
+    public function getDifferentGetterTyped(): array
+    {
+        return $this->differentGetterTyped->getArrayCopy();
+    }
+
+    /**
+     * @param DocblockFoo[] $foos
+     */
+    public function setDifferentSetterTyped(array $foos): void
+    {
+        $this->differentSetterTyped = new ArrayObject($foos);
     }
 }

--- a/tests/Mock/ExcludedClassMock.php
+++ b/tests/Mock/ExcludedClassMock.php
@@ -21,5 +21,5 @@ class ExcludedClassMock
      * @Type("Tebru\Gson\Test\Mock\GsonMock")
      */
     private $foo;
-    private $bar;
+    private bool $bar;
 }

--- a/tests/Mock/UserMock.php
+++ b/tests/Mock/UserMock.php
@@ -33,10 +33,7 @@ class UserMock
      */
     private $password;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
     /**
      * @var AddressMock

--- a/tests/Mock/UserMockVirtual.php
+++ b/tests/Mock/UserMockVirtual.php
@@ -35,10 +35,7 @@ class UserMockVirtual
      */
     private $password;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
     /**
      * @var AddressMock

--- a/tests/Unit/Internal/Data/ReflectionPropertySetFactoryTest.php
+++ b/tests/Unit/Internal/Data/ReflectionPropertySetFactoryTest.php
@@ -48,6 +48,7 @@ class ReflectionPropertySetFactoryTest extends TestCase
             new ReflectionProperty(ChildClass::class, 'overridden'),
             new ReflectionProperty(ChildClass::class, 'withTypehint'),
             new ReflectionProperty(ChildClass::class, 'default'),
+            new ReflectionProperty(ChildClass::class, 'typedArray'),
             new ReflectionProperty(ChildClassParent::class, 'baz'),
             new ReflectionProperty(ChildClassParent2::class, 'qux'),
             new ReflectionProperty(ChildClassParent::class, 'bar'),

--- a/tests/Unit/Internal/TypeTokenFactoryTest.php
+++ b/tests/Unit/Internal/TypeTokenFactoryTest.php
@@ -46,6 +46,40 @@ class TypeTokenFactoryTest extends TestCase
         self::assertSame(ChildClass::class, $phpType->getRawType());
     }
 
+    public function testCreateFromAnnotationWithTypedProperty(): void
+    {
+        $type = new Type(['value' => ChildClass::class]);
+        $annotations = new AnnotationCollection();
+        $annotations->add($type);
+
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(ChildClass::class, 'typedArray');
+        $phpType = $factory->create($annotations, null, null, $property);
+
+        self::assertSame(ChildClass::class, $phpType->getRawType());
+    }
+
+    public function testCreateFromPropertyType(): void
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(ChildClass::class, 'typedArray');
+        $phpType = $factory->create($annotations, null, null, $property);
+
+        self::assertSame('array', $phpType->getRawType());
+    }
+
+    public function testCreateFromArrayPropertyTypeWithGeneric(): void
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(DocblockMock::class, 'fullyTypedArray');
+        $phpType = $factory->create($annotations, null, null, $property);
+
+        self::assertSame(TypeToken::HASH, $phpType->getRawType());
+        self::assertSame(TypeToken::INTEGER, $phpType->getGenerics()[0]->getRawType());
+    }
+
     public function testCreateFromSetterTypehint(): void
     {
         $annotations = new AnnotationCollection();
@@ -355,6 +389,28 @@ class TypeTokenFactoryTest extends TestCase
         $factory = new TypeTokenFactory();
         $property = new ReflectionProperty(DocblockMock::class, 'differentSetter');
         $setter = new ReflectionMethod(DocblockMock::class, 'setDifferentSetter');
+        $phpType = $factory->create($annotations, null, $setter, $property);
+
+        self::assertSame('array<Tebru\Gson\Test\Mock\DocblockType\DocblockFoo>', (string)$phpType);
+    }
+
+    public function testCreateFromDocblockDifferentGetterWithTypedProperty(): void
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(DocblockMock::class, 'differentGetterTyped');
+        $getter = new ReflectionMethod(DocblockMock::class, 'getDifferentGetterTyped');
+        $phpType = $factory->create($annotations, $getter, null, $property);
+
+        self::assertSame('array<Tebru\Gson\Test\Mock\DocblockType\DocblockFoo>', (string)$phpType);
+    }
+
+    public function testCreateFromDocblockDifferentSetterWithTypedProperty(): void
+    {
+        $annotations = new AnnotationCollection();
+        $factory = new TypeTokenFactory();
+        $property = new ReflectionProperty(DocblockMock::class, 'differentSetterTyped');
+        $setter = new ReflectionMethod(DocblockMock::class, 'setDifferentSetterTyped');
         $phpType = $factory->create($annotations, null, $setter, $property);
 
         self::assertSame('array<Tebru\Gson\Test\Mock\DocblockType\DocblockFoo>', (string)$phpType);


### PR DESCRIPTION
Closes https://github.com/tebru/gson-php/issues/51

❗ **Breaking Change: Requires PHP 7.4 (can this be avoided?)**

This adds checking of the reflection property type just after checking getter and setter types.